### PR TITLE
change current_user, is_professor and is_student

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  include ApplicationHelper
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,18 +1,24 @@
 module ApplicationHelper
 	def logged_in?
-    session[:user_id] != nil
+    current_user != nil
   end
 
   def current_user
-     User.find(session[:user_id])
+    if is_professor?
+      Professor.find(session[:professor_id])
+    elsif is_student?
+      Student.find(session[:student_id])
+    else
+      nil
+    end
   end
 
   def is_professor?
-  	Professor.all.include?(current_user)
+  	session[:professor_id] != nil
   end
 
   def is_student?
-  	Student.all.include?(current_user)
+    session[:student_id] != nil
   end
 
   def is_admin?


### PR DESCRIPTION
change current user method to assume that session will contain a :professor_id or a :student_id rather than a :user_id,
and changed is_professor and is_student to simply check for the appropriate id in the session.
current_user should now return Professor or Student object depending on who's logged in.
